### PR TITLE
bugfix/allow only numbers in customers create/update

### DIFF
--- a/app/assets/builds/application.js.LICENSE.txt
+++ b/app/assets/builds/application.js.LICENSE.txt
@@ -24,6 +24,17 @@
  */
 
 /*!
+ * Sizzle CSS Selector Engine v2.3.9
+ * https://sizzlejs.com/
+ *
+ * Copyright JS Foundation and other contributors
+ * Released under the MIT license
+ * https://js.foundation/
+ *
+ * Date: 2022-12-19
+ */
+
+/*!
  * jQuery JavaScript Library v3.6.1
  * https://jquery.com/
  *
@@ -35,6 +46,20 @@
  * https://jquery.org/license
  *
  * Date: 2022-08-26T17:52Z
+ */
+
+/*!
+ * jQuery JavaScript Library v3.6.3
+ * https://jquery.com/
+ *
+ * Includes Sizzle.js
+ * https://sizzlejs.com/
+ *
+ * Copyright OpenJS Foundation and other contributors
+ * Released under the MIT license
+ * https://jquery.org/license
+ *
+ * Date: 2022-12-20T21:28Z
  */
 
 /*!

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -21,4 +21,6 @@
 class Customer < ApplicationRecord
   has_many :sales
   acts_as_tenant :account
+
+  validates :phone, :cellphone, numericality: { only_integer: true }, allow_blank: true
 end

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -32,8 +32,8 @@
                 <td><%= link_to customer.id, customer_path(customer) %></td>
                 <td><%= customer.name %></td>
                 <td><%= customer.email %></td>
-                <td><%= customer.cellphone %></td>
-                <td><%= customer.phone %></td>
+                <td><%= number_to_phone(customer.cellphone, pattern: /(\d{1,4})(\d{5})(\d{4})$/, area_code: true) %></td>
+                <td><%= number_to_phone(customer.phone, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true) %></td>
                 <td><%= customer.cpf %></td>
                 <td><%= df(customer.created_at) %></td>
                 <td>

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -15,9 +15,9 @@
         <dt><strong><%= model_class.human_attribute_name(:email) %>:</strong></dt>
         <dd><%= @customer.email %></dd>
         <dt><strong><%= model_class.human_attribute_name(:cellphone) %>:</strong></dt>
-        <dd><%= @customer.cellphone %></dd>
+        <dd><%= number_to_phone(@customer.cellphone, pattern: /(\d{1,4})(\d{5})(\d{4})$/, area_code: true) %></dd>
         <dt><strong><%= model_class.human_attribute_name(:phone) %>:</strong></dt>
-        <dd><%= @customer.phone %></dd>
+        <dd><%= number_to_phone(@customer.phone, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true) %></dd>
         <dt><strong><%= model_class.human_attribute_name(:cpf) %>:</strong></dt>
         <dd><%= @customer.cpf %></dd>
       </dl>

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -24,7 +24,8 @@ FactoryBot.define do
   factory :customer do
     name { Faker::Name.name }
     email { Faker::Internet.email }
-    phone { Faker::PhoneNumber.phone_number }
+    phone { Faker::Number.number(digits: 10) }
+    cellphone { Faker::Number.number(digits: 11) }
     cpf { Faker::Number.number(digits: 11) }
 
     account_id { create(:account).id }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -31,5 +31,25 @@ RSpec.describe Customer, type: :model do
     it 'is valid' do
       expect(customer).to be_valid
     end
+
+    it 'is valid when phone is a number' do
+      customer.phone = '1195963325'
+      expect(customer).to be_valid
+    end
+  
+    it 'is valid when cellphone is a number' do
+      customer.cellphone = '1195963325'
+      expect(customer).to be_valid
+    end
+  
+    it 'is invalid when phone is not a number' do
+      customer.phone = 'Im not a number'
+      expect(customer).not_to be_valid
+    end
+  
+    it 'is invalid when cellphone is not a number' do
+      customer.cellphone = 'Im not a number'
+      expect(customer).not_to be_valid
+    end  
   end
 end


### PR DESCRIPTION
Fix customers phone and cellphone inputs. The validation only allows numbers or blank. It also shows formatted numbers e.g.: (99) 9999-9999 but only saves 9999999999 in database. Important: there's no mask in the cellphone or phone inputs...the formatted number uses the "number_to_phone" helper just to show the formatted numbers to the user. 