### PR TITLE
[/318] Exibe toastr quando ocorre falha no login

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,7 @@
   <div class="card-header"><h2><%= t(".title") %></h2></div>
 
   <div class="card-body">
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'needs-validation' }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'needs-validation', 'data-turbo': 'false' }) do |f| %>
       <div class="form-group">
         <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -13,6 +13,8 @@
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
   <%= stylesheet_link_tag 'mobile', media: 'all', 'data-turbo-track': 'reload' if platform.mobile_app? %>
 
+  <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+
   <link rel="icon" href="https://purple-stock.s3-sa-east-1.amazonaws.com/favicon_purple.ico"/>
   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.css">
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css"/>
@@ -42,7 +44,6 @@
 </div>
 
 <!-- scripts -->
-<%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 <script type="text/javascript" src="https://a.kabachnik.info/assets/js/onscan.min.js"></script>
 
 </body>

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'devise/sessions/new.html.erb', type: :view do
+  include Capybara::DSL
+
+  context 'when sign in is successful' do
+    let!(:user) { FactoryBot.create(:user) }
+
+    it 'greet the user' do
+      visit root_path
+
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+
+      click_button 'Entrar'
+
+      expect(page).to have_content("Olá, #{user.email}")
+    end
+  end
+
+  context 'when sign in fails' do
+    it 'display error message' do
+      visit root_path
+
+      fill_in 'user_email', with: 'random@email.com'
+      fill_in 'user_password', with: 'random_password'
+      click_button 'Entrar'
+
+      expect(page).to have_content('Email ou senha inválida.')
+    end
+  end
+end


### PR DESCRIPTION
Fix #318 

## Solução proposta

No rails 7, o turbo precisa que seja feito um redirecionamento para funcionar corretamente. Para adequar o funcionamento atual ao que o tubo espera, seria necessário a criação de um controller customizado do `Devise` para  contornar o comportamento padrão.

Uma alternativa que dispença a necessidade de um `monkey patch` seria desligar o turbo para o formulário de login, e com isso permite que o toastr volte a funcionar corretamente em caso de falha no login por erros de email/senha

## Resultado

![image](https://github.com/Purple-Stock/open-erp/assets/71977763/5783fc52-20aa-49d5-81a2-4594ed1f067f)

