### PR TITLE
Issue 8

### DIFF
--- a/app/controllers/bling_order_item_histories_controller.rb
+++ b/app/controllers/bling_order_item_histories_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# a
+
 # There is a necessity to know the revenue from the last 15 days
 # In order to take better commercial decisions.
 class BlingOrderItemHistoriesController < ApplicationController

--- a/app/controllers/bling_order_item_histories_controller.rb
+++ b/app/controllers/bling_order_item_histories_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+# a
 # There is a necessity to know the revenue from the last 15 days
 # In order to take better commercial decisions.
 class BlingOrderItemHistoriesController < ApplicationController

--- a/app/models/revenue_estimation.rb
+++ b/app/models/revenue_estimation.rb
@@ -17,6 +17,7 @@ class RevenueEstimation < ApplicationRecord
 
   validates :revenue, :average_ticket, :date, presence: :true
   validates :revenue, numericality: :true
+  validates :average_ticket, numericality: { greater_than: 0 }
 
   before_save :calculate_quantity
   before_validation :set_date
@@ -31,13 +32,7 @@ class RevenueEstimation < ApplicationRecord
   private
 
   def calculate_quantity
-    return unless valid_numeric_inputs?
-
     self.quantity = (revenue.to_f / average_ticket.to_f).to_i
-  end
-
-  def valid_numeric_inputs?
-    revenue.is_a?(Numeric) && average_ticket.is_a?(Numeric) && average_ticket.to_f != 0
   end
 
   def set_date

--- a/app/models/revenue_estimation.rb
+++ b/app/models/revenue_estimation.rb
@@ -35,7 +35,7 @@ class RevenueEstimation < ApplicationRecord
   private
 
   def calculate_quantity
-    self.quantity = (revenue.to_f / average_ticket.to_f).to_i
+    self.quantity = (revenue / average_ticket).to_i
   end
 
   def set_date

--- a/app/models/revenue_estimation.rb
+++ b/app/models/revenue_estimation.rb
@@ -12,6 +12,9 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
+# RevenueEstimation exists to answer a question:
+# How much Order Items to sale in order to achieve the average ticket
+# for the given month?
 class RevenueEstimation < ApplicationRecord
   attr_accessor :month
 

--- a/app/models/revenue_estimation.rb
+++ b/app/models/revenue_estimation.rb
@@ -12,9 +12,6 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
-# RevenueEstimation exists to answer a question:
-# How much Order Items to sale in order to achieve the average ticket
-# for the given month?
 class RevenueEstimation < ApplicationRecord
   attr_accessor :month
 
@@ -34,7 +31,13 @@ class RevenueEstimation < ApplicationRecord
   private
 
   def calculate_quantity
-    self.quantity = (revenue / average_ticket).to_i
+    return unless valid_numeric_inputs?
+
+    self.quantity = (revenue.to_f / average_ticket.to_f).to_i
+  end
+
+  def valid_numeric_inputs?
+    revenue.is_a?(Numeric) && average_ticket.is_a?(Numeric) && average_ticket.to_f != 0
   end
 
   def set_date

--- a/app/views/revenue_estimations/_form.html.erb
+++ b/app/views/revenue_estimations/_form.html.erb
@@ -30,7 +30,7 @@
   <div class="form-row">
     <div class="form-group col-6">
       <%= f.label :month, :class => 'control-label' %>
-      <%= f.select :month, options_for_select((1..12).map { |m| [I18n.t("date.month_names")[m], m] }, f.object.date&.month), {}, class: 'form-control' %>
+      <%= f.select :month, options_for_select((1..12).map { |m| [I18n.t("date.month_names")[m], m] }, Time.now.month), {}, class: 'form-control' %>
     </div>
 
     <div class="form-group col-6">

--- a/app/views/revenue_estimations/_form.html.erb
+++ b/app/views/revenue_estimations/_form.html.erb
@@ -30,12 +30,12 @@
   <div class="form-row">
     <div class="form-group col-6">
       <%= f.label :month, :class => 'control-label' %>
-      <%= f.number_field :month, :class => 'form-control', value: f.object.date&.month %>
+      <%= f.select :month, options_for_select((1..12).map { |m| [I18n.t("date.month_names")[m], m] }, f.object.date&.month), {}, class: 'form-control' %>
     </div>
 
     <div class="form-group col-6">
       <%= f.label :revenue, :class => 'control-label' %>
-      <%= f.text_field :revenue, :class => 'form-control' %>
+      <%= f.text_field :revenue, value: number_to_currency(f.object.revenue, precision: 2), class: 'form-control' %>
     </div>
 
     <div class="form-group col-6">
@@ -45,7 +45,7 @@
 
     <div class="form-group col-6">
       <%= f.label :average_ticket, :class => 'control-label' %>
-      <%= f.text_field :average_ticket, :class => 'form-control' %>
+      <%= f.text_field :average_ticket, value: number_to_currency(f.object.average_ticket, precision: 2), class: 'form-control' %>
     </div>
 
     <div class="form-group">

--- a/config/locales/pt-BR.models.revenue_estimations.yml
+++ b/config/locales/pt-BR.models.revenue_estimations.yml
@@ -18,4 +18,4 @@ pt-BR:
         updated: Estimativa da Receita Atualizada
         deleted: Estimativa da Receita Deletada
         new: Nova Estimativa da Receita
-        month: Número do Mês
+        month: Mês

--- a/spec/models/revenue_estimation_spec.rb
+++ b/spec/models/revenue_estimation_spec.rb
@@ -48,17 +48,8 @@ RSpec.describe RevenueEstimation, type: :model do
         expect(subject.date.month).to eq(10)
       end
     end
-  end
-
-  describe '#calculate_quantity' do
-    context 'with valid inputs' do
-      it 'calculates quantity based on revenue and average_ticket' do
-        revenue_estimation = create(:revenue_estimation, revenue: 1000, average_ticket: 50)
-        expect(revenue_estimation.quantity).to eq(20)
-      end
-    end
-
-    context 'with invalid inputs' do
+     
+    context "invalid" do
       it 'handles when revenue or average_ticket is a string' do
         revenue_estimation = build(:revenue_estimation, revenue: 'invalid', average_ticket: 'invalid')
         expect(revenue_estimation).not_to be_valid
@@ -67,6 +58,15 @@ RSpec.describe RevenueEstimation, type: :model do
       it 'handles zero average_ticket' do
         revenue_estimation = build(:revenue_estimation, revenue: 50, average_ticket: 0)
         expect(revenue_estimation).not_to be_valid
+      end
+    end
+  end
+
+  describe '#calculate_quantity' do
+    context 'with valid inputs' do
+      it 'calculates quantity based on revenue and average_ticket' do
+        revenue_estimation = create(:revenue_estimation, revenue: 1000, average_ticket: 50)
+        expect(revenue_estimation.quantity).to eq(20)
       end
     end
   end

--- a/spec/models/revenue_estimation_spec.rb
+++ b/spec/models/revenue_estimation_spec.rb
@@ -48,17 +48,5 @@ RSpec.describe RevenueEstimation, type: :model do
         expect(subject.date.month).to eq(10)
       end
     end
-     
-    context "invalid" do
-      it 'handles when revenue or average_ticket is a string' do
-        revenue_estimation = build(:revenue_estimation, revenue: 'invalid', average_ticket: 'invalid')
-        expect(revenue_estimation).not_to be_valid
-      end
-
-      it 'handles zero average_ticket' do
-        revenue_estimation = build(:revenue_estimation, revenue: 50, average_ticket: 0)
-        expect(revenue_estimation).not_to be_valid
-      end
-    end
   end
 end

--- a/spec/models/revenue_estimation_spec.rb
+++ b/spec/models/revenue_estimation_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe RevenueEstimation, type: :model do
     it { is_expected.to validate_presence_of(:revenue) }
     it { is_expected.to validate_presence_of(:date) }
     it { is_expected.to validate_numericality_of(:revenue) }
+    it { is_expected.to validate_numericality_of(:average_ticket).is_greater_than(0) }
   end
 
   describe '#save' do
@@ -52,29 +53,20 @@ RSpec.describe RevenueEstimation, type: :model do
   describe '#calculate_quantity' do
     context 'with valid inputs' do
       it 'calculates quantity based on revenue and average_ticket' do
-        revenue_estimation = RevenueEstimation.new(revenue: 1000, average_ticket: 50)
-        revenue_estimation.send(:calculate_quantity)
+        revenue_estimation = create(:revenue_estimation, revenue: 1000, average_ticket: 50)
         expect(revenue_estimation.quantity).to eq(20)
       end
     end
 
     context 'with invalid inputs' do
       it 'handles when revenue or average_ticket is a string' do
-        revenue_estimation = RevenueEstimation.new(revenue: 'invalid', average_ticket: 'invalid')
-        revenue_estimation.send(:calculate_quantity)
-        expect(revenue_estimation.quantity).to be_nil
+        revenue_estimation = build(:revenue_estimation, revenue: 'invalid', average_ticket: 'invalid')
+        expect(revenue_estimation).not_to be_valid
       end
 
       it 'handles zero average_ticket' do
-        revenue_estimation = RevenueEstimation.new(revenue: 1000, average_ticket: 0)
-        revenue_estimation.send(:calculate_quantity)
-        expect(revenue_estimation.quantity).to be_nil
-      end
-
-      it 'handles zero revenue' do
-        revenue_estimation = RevenueEstimation.new(revenue: 0, average_ticket: 50)
-        revenue_estimation.send(:calculate_quantity)
-        expect(revenue_estimation.quantity).to be_zero
+        revenue_estimation = build(:revenue_estimation, revenue: 50, average_ticket: 0)
+        expect(revenue_estimation).not_to be_valid
       end
     end
   end

--- a/spec/models/revenue_estimation_spec.rb
+++ b/spec/models/revenue_estimation_spec.rb
@@ -48,4 +48,34 @@ RSpec.describe RevenueEstimation, type: :model do
       end
     end
   end
+
+  describe '#calculate_quantity' do
+    context 'with valid inputs' do
+      it 'calculates quantity based on revenue and average_ticket' do
+        revenue_estimation = RevenueEstimation.new(revenue: 1000, average_ticket: 50)
+        revenue_estimation.send(:calculate_quantity)
+        expect(revenue_estimation.quantity).to eq(20)
+      end
+    end
+
+    context 'with invalid inputs' do
+      it 'handles when revenue or average_ticket is a string' do
+        revenue_estimation = RevenueEstimation.new(revenue: 'invalid', average_ticket: 'invalid')
+        revenue_estimation.send(:calculate_quantity)
+        expect(revenue_estimation.quantity).to be_nil
+      end
+
+      it 'handles zero average_ticket' do
+        revenue_estimation = RevenueEstimation.new(revenue: 1000, average_ticket: 0)
+        revenue_estimation.send(:calculate_quantity)
+        expect(revenue_estimation.quantity).to be_nil
+      end
+
+      it 'handles zero revenue' do
+        revenue_estimation = RevenueEstimation.new(revenue: 0, average_ticket: 50)
+        revenue_estimation.send(:calculate_quantity)
+        expect(revenue_estimation.quantity).to be_zero
+      end
+    end
+  end
 end

--- a/spec/models/revenue_estimation_spec.rb
+++ b/spec/models/revenue_estimation_spec.rb
@@ -61,13 +61,4 @@ RSpec.describe RevenueEstimation, type: :model do
       end
     end
   end
-
-  describe '#calculate_quantity' do
-    context 'with valid inputs' do
-      it 'calculates quantity based on revenue and average_ticket' do
-        revenue_estimation = create(:revenue_estimation, revenue: 1000, average_ticket: 50)
-        expect(revenue_estimation.quantity).to eq(20)
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Correção no cálculo de estimativas de receita

Olá! Esta é minha primeira contribuição para este projeto open source.
Fala pessoal! Primeira contribuição no projeto. Se puder melhorar em algom fico a disposição.

close #8

### Resumo das Alterações

Fiz correções no cálculo das estimativas de receita para resolver um problema em que a entrada de valores como strings resultava em um erro 500. Aqui estão os detalhes das alterações:

#### `app/models/revenue_estimation.rb`

- Alteração na função `calculate_quantity` para lidar com entradas não numéricas.
- Mudança para assegurar que `revenue` e `average_ticket` sejam valores numéricos antes do cálculo.
- O método `valid_numeric_inputs?` verifica se `revenue` e `average_ticket` são numéricos e se `average_ticket` não é zero.

#### `app/views/revenue_estimations/_form.html.erb`

- Mudança no input de mês de número livre para dropdown com todos os meses por extenso. Optei por essa alteação para restrigir o usuário de colocar um número fora do range, alé, de ficar mais intuitivo.
- Adicionei formatação de currency nos campos de valor

![image](https://github.com/Purple-Stock/open-erp/assets/61502117/fd57c77e-816f-4c26-981f-3a7e9b2b92f8)
![image](https://github.com/Purple-Stock/open-erp/assets/61502117/66ec0dea-c7ed-4901-b699-c40c09f857d3)
