### PR TITLE
refactor bling_order_item.rb, bling_order_item.rb: task #56

### DIFF
--- a/app/jobs/order_items_job.rb
+++ b/app/jobs/order_items_job.rb
@@ -1,10 +1,11 @@
 class OrderItemsJob < ApplicationJob
   queue_as :items
 
-  def perform(record)
+  def perform(bling_order_id)
+    record = BlingOrderItem.find_by(bling_order_id:)
     account_id = record.account_id
     items_attributes = []
-    order = Services::Bling::FindOrder.call(id: record.bling_order_id, order_command: 'find_order', tenant: account_id)
+    order = Services::Bling::FindOrder.call(id: bling_order_id, order_command: 'find_order', tenant: account_id)
     raise(StandardError, order['error']) if order['error'].present?
 
     order['data']['itens'].each do |item|

--- a/app/models/bling_order_item.rb
+++ b/app/models/bling_order_item.rb
@@ -135,7 +135,7 @@ class BlingOrderItem < ApplicationRecord
   def synchronize_items
     return unless items.empty?
 
-    OrderItemsJob.perform_later(self)
+    OrderItemsJob.perform_later(bling_order_id)
   end
 
   def self.bulk_synchronize_items(collection)


### PR DESCRIPTION
Good practice: do not pass the record as an argument since it will consume lot of memory when in any mass actions. close #56 