### PR TITLE
fix bling_order_item.rb: task 68

### DIFF
--- a/app/models/bling_order_item.rb
+++ b/app/models/bling_order_item.rb
@@ -119,13 +119,10 @@ class BlingOrderItem < ApplicationRecord
   def self.update_yourself(self_collection)
     account_id = self_collection.first.account_id
 
-    self_collection.find_in_batches(batch_size: 100) do |sub_collection|
-      GoodJob::Bulk.enqueue do
-        sub_collection.each do |record|
-          BlingOrderJobUpdater.perform_later(record, account_id)
-        end
+    GoodJob::Bulk.enqueue do
+      self_collection.each do |record|
+        BlingOrderJobUpdater.perform_later(record, account_id)
       end
-      sleep 10 if Rails.env.eql?('production') || Rails.env.eql?('staging')
     end
   end
 


### PR DESCRIPTION
do not sub group batch, it raise error since the sub group in a enumerable array not a active record relation.