### PR TITLE
fix daily_revenue_chart.js: task #162

### DIFF
--- a/app/javascript/chartjs/daily_revenue_chart.js
+++ b/app/javascript/chartjs/daily_revenue_chart.js
@@ -4,6 +4,9 @@ $(document).ready(function (){
         dailyRevenueChartBar = new Chart(chartJsBarDailyRevenueDomElement, cfg);
     }
     let dailyRevenue = $('#daily_revenue').val();
+    if(typeof dailyRevenue === 'undefined'){
+        return;
+    }
     let data = JSON.parse(dailyRevenue);
     let cfg = {
         type: 'bar',


### PR DESCRIPTION
add guard clause to plotDailyRevenueChartBar. If the dailyRevenue variable is undefine it means the template is not loading the html element.
close #162 