### PR TITLE
cache bundler install results to speed up gems installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.9.0'
+          cache: 'yarn'
+      - run: yarn install --check-files
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -43,15 +45,6 @@ jobs:
           ruby-version: 3.2.2
           # runs 'bundle install' and cache installed gems automatically
           bundler-cache: true
-
-      - name: Install dependencies
-        env:
-          RAILS_ENV: test
-        run: |
-          npm install -g yarn@1.22.19
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-          yarn install --check-files
 
       - name: Setup test database
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,9 @@ jobs:
         with:
           node-version: '20.9.0'
           cache: 'yarn'
-      - run: yarn install --check-files
+      - run: | 
+          npm install -g yarn@1.22.19
+          yarn install --check-files
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.2
+          # runs 'bundle install' and cache installed gems automatically
+          bundler-cache: true
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
Old average time for this workflow was more than 3 minutes. Currently reduced to 2 minutes. Cached ruby and node dependencies.
How to [cache node](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data)
How to [cache ruby](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically)